### PR TITLE
add support for images based on Arch Linux

### DIFF
--- a/appinfo/appinfo.go
+++ b/appinfo/appinfo.go
@@ -177,7 +177,7 @@ func getResolvedParameters(env environment) map[string]string {
 			"            addgroup -g ${GROUPID} ${GROUPNAME} || \\\n" +
 			"            # busybox\\\n" +
 			"            addgroup --gid ${GROUPID} ${GROUPNAME} || \\\n" +
-			"            # fedora\\\n" +
+			"            # fedora / arch linux\\\n" +
 			"            groupadd --gid ${GROUPID} ${GROUPNAME} \\\n" +
 			"        ) > /dev/null 2>&1 ; \\\n" +
 			"    fi ; \\\n" +
@@ -188,7 +188,9 @@ func getResolvedParameters(env environment) map[string]string {
 			"            # ubuntu\\\n" +
 			"            adduser --home \"${HOME}\" --uid ${USERID} --gecos \"\" --ingroup ${GROUPNAME} --disabled-password ${USERNAME} || \\\n" +
 			"            # busybox\\\n" +
-			"            adduser -h \"${HOME}\" -u ${USERID} -D -H -G ${GROUPNAME} ${USERNAME} \\\n" +
+			"            adduser -h \"${HOME}\" -u ${USERID} -D -H -G ${GROUPNAME} ${USERNAME} || \\\n" +
+			"            # arch linux\\\n" +
+			"            useradd --no-user-group --gid ${GROUPID} --home-dir \"${HOME}\" --create-home ${USERNAME} \\\n" +
 			"        ) > /dev/null 2>&1 ; \\\n" +
 			"    fi ;\n\n" +
 			"USER ${USERNAME}",


### PR DESCRIPTION
### Problem
At the moment containerflight is not able to create a user for images based on an Arch Linux base image (such as `base/archlinux`).

### Example
The following minimal example fails to build during user creation:
```
#!/usr/local/bin/containerflight run

image:
    base: docker://base/archlinux:latest
    dockerfile: |
        ENTRYPOINT ["/bin/bash"]
```
### Reason
Arch Linux uses `useradd` instead of `adduser` to add new users.

### Solution
This pull request adds the appropriate `useradd` command to the commands that are generated by containerflight for each Dockerfile.