### PR TITLE
fix user id in images based on Arch Linux

### DIFF
--- a/appinfo/appinfo.go
+++ b/appinfo/appinfo.go
@@ -190,7 +190,7 @@ func getResolvedParameters(env environment) map[string]string {
 			"            # busybox\\\n" +
 			"            adduser -h \"${HOME}\" -u ${USERID} -D -H -G ${GROUPNAME} ${USERNAME} || \\\n" +
 			"            # arch linux\\\n" +
-			"            useradd --no-user-group --gid ${GROUPID} --home-dir \"${HOME}\" --create-home ${USERNAME} \\\n" +
+			"            useradd --no-user-group --gid ${GROUPID} --uid ${USERID} --home-dir \"${HOME}\" --create-home ${USERNAME} \\\n" +
 			"        ) > /dev/null 2>&1 ; \\\n" +
 			"    fi ;\n\n" +
 			"USER ${USERNAME}",

--- a/appinfo/appinfo_test.go
+++ b/appinfo/appinfo_test.go
@@ -321,7 +321,7 @@ RUN if ! getent group testgroup > /dev/null 2>&1; then \
             # busybox\
             adduser -h "/home" -u 1234 -D -H -G testgroup testuser || \
             # arch linux\
-            useradd --no-user-group --gid 5678 --home-dir "/home" --create-home testuser \
+            useradd --no-user-group --gid 5678 --uid 1234 --home-dir "/home" --create-home testuser \
         ) > /dev/null 2>&1 ; \
     fi ;
 


### PR DESCRIPTION
The support for images based on Arch Linux introduced in  #2 is incomplete:
- `--uid` flag for `useradd` is missing, so the created user always has id 1000 (the first non-system user id).
- This PR fixes this by adding the missing flag.